### PR TITLE
Add user management function

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,3 +45,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'devise'

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'pg', '~> 0.18'
 gem 'puma', '~> 3.7'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
+gem 'bootstrap-sass', '3.3.6'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby '2.4.3'
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
@@ -51,3 +52,7 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'devise'
+
+group :production do
+  gem 'rails_12factor'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,9 @@ gem 'jbuilder', '~> 2.5'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+# Use jquery as the JavaScript library
+gem 'jquery-rails'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (8.0.0)
+    bcrypt (3.1.11)
     bindex (0.5.0)
     builder (3.2.3)
     byebug (9.1.0)
@@ -51,6 +52,12 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     crass (1.0.3)
+    devise (4.4.1)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0, < 5.2)
+      responders
+      warden (~> 1.2.3)
     erubi (1.7.0)
     execjs (2.7.0)
     ffi (1.9.18)
@@ -78,6 +85,7 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
+    orm_adapter (0.5.0)
     pg (0.21.0)
     puma (3.10.0)
     rack (2.0.3)
@@ -110,6 +118,9 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    responders (2.4.0)
+      actionpack (>= 4.2.0, < 5.3)
+      railties (>= 4.2.0, < 5.3)
     ruby_dep (1.5.0)
     sass (3.5.3)
       sass-listen (~> 4.0.0)
@@ -141,6 +152,8 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
+    warden (1.2.7)
+      rack (>= 1.0)
     web-console (3.5.1)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -156,6 +169,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   coffee-rails (~> 4.2)
+  devise
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   pg (~> 0.18)
@@ -169,4 +183,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,11 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.5)
+    rails_stdout_logging (0.0.5)
     railties (5.1.4)
       actionpack (= 5.1.4)
       activesupport (= 5.1.4)
@@ -186,12 +191,16 @@ DEPENDENCIES
   pg (~> 0.18)
   puma (~> 3.7)
   rails (~> 5.1.4)
+  rails_12factor
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+
+RUBY VERSION
+   ruby 2.4.3p205
 
 BUNDLED WITH
    1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,10 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jquery-rails (4.3.1)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -171,6 +175,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   jbuilder (~> 2.5)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   pg (~> 0.18)
   puma (~> 3.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,8 +39,13 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (8.0.0)
+    autoprefixer-rails (8.0.0)
+      execjs
     bcrypt (3.1.11)
     bindex (0.5.0)
+    bootstrap-sass (3.3.6)
+      autoprefixer-rails (>= 5.2.1)
+      sass (>= 3.3.4)
     builder (3.2.3)
     byebug (9.1.0)
     coffee-rails (4.2.2)
@@ -171,6 +176,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bootstrap-sass (= 3.3.6)
   byebug
   coffee-rails (~> 4.2)
   devise

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,5 +10,6 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require jquery
 //= require rails-ujs
 //= require_tree .

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,3 +13,4 @@
 //= require jquery
 //= require rails-ujs
 //= require_tree .
+//= require bootstrap-sprockets

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -13,3 +13,6 @@
  *= require_tree .
  *= require_self
  */
+
+@import "bootstrap-sprockets";
+@import "bootstrap";

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,4 +1,14 @@
-#wrap {
-  max-width: 1024px;
-  margin: 0 auto;
+h2 {
+  font-weight: bold !important;
+}
+
+.navbar {
+  padding-top: 15px;
+  padding-left: 15px;
+}
+.site-title {
+  color: #007bff;
+  text-decoration: none;
+  padding: 0.5rem 1rem;
+  font-size: 1.1em;
 }

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,0 +1,4 @@
+#wrap {
+  max-width: 1024px;
+  margin: 0 auto;
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,6 +1,9 @@
 h2 {
   font-weight: bold !important;
 }
+label {
+  font-size: 1.1em;
+}
 
 .navbar {
   padding-top: 15px;

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -5,10 +5,19 @@ h2 {
 .navbar {
   padding-top: 15px;
   padding-left: 15px;
-}
-.site-title {
-  color: #007bff;
-  text-decoration: none;
-  padding: 0.5rem 1rem;
-  font-size: 1.1em;
+  .site-title {
+    color: #007bff;
+    text-decoration: none;
+    padding: 0.5rem 1rem;
+    font-size: 1.1em;
+  }
+  .nav-title {
+    color: rgba(0,0,0,0.5);
+        padding-right: .5rem;
+    padding-left: .5rem;
+    &:hover {
+      text-decoration: none;
+      color: #212529;
+    }
+  }
 }

--- a/app/assets/stylesheets/utilities.css
+++ b/app/assets/stylesheets/utilities.css
@@ -1,0 +1,1152 @@
+@charset "UTF-8";
+.clear {
+  clear: both;
+}
+
+.href {
+  cursor: pointer;
+}
+
+/*----------------------------------------------------
+マージン調整
+----------------------------------------------------*/
+.mt_0 {
+  margin-top: 0 !important;
+}
+
+.mb_0 {
+  margin-bottom: 0 !important;
+}
+
+.ml_0 {
+  margin-left: 0 !important;
+}
+
+.mr_0 {
+  margin-right: 0 !important;
+}
+
+.mt_05 {
+  margin-top: 5px !important;
+}
+
+.mb_05 {
+  margin-bottom: 5px !important;
+}
+
+.ml_05 {
+  margin-left: 5px !important;
+}
+
+.mr_05 {
+  margin-right: 5px !important;
+}
+
+.nmt_05 {
+  margin-top: -5px !important;
+}
+
+.nmb_05 {
+  margin-bottom: -5px !important;
+}
+
+.nml_05 {
+  margin-left: -5px !important;
+}
+
+.nmr_05 {
+  margin-right: -5px !important;
+}
+
+.mt_10 {
+  margin-top: 10px !important;
+}
+
+.mb_10 {
+  margin-bottom: 10px !important;
+}
+
+.ml_10 {
+  margin-left: 10px !important;
+}
+
+.mr_10 {
+  margin-right: 10px !important;
+}
+
+.nmt_10 {
+  margin-top: -10px !important;
+}
+
+.nmb_10 {
+  margin-bottom: -10px !important;
+}
+
+.nml_10 {
+  margin-left: -10px !important;
+}
+
+.nmr_10 {
+  margin-right: -10px !important;
+}
+
+.mt_15 {
+  margin-top: 15px !important;
+}
+
+.mb_15 {
+  margin-bottom: 15px !important;
+}
+
+.ml_15 {
+  margin-left: 15px !important;
+}
+
+.mr_15 {
+  margin-right: 15px !important;
+}
+
+.nmt_15 {
+  margin-top: -15px !important;
+}
+
+.nmb_15 {
+  margin-bottom: -15px !important;
+}
+
+.nml_15 {
+  margin-left: -15px !important;
+}
+
+.nmr_15 {
+  margin-right: -15px !important;
+}
+
+.mt_20 {
+  margin-top: 20px !important;
+}
+
+.mb_20 {
+  margin-bottom: 20px !important;
+}
+
+.ml_20 {
+  margin-left: 20px !important;
+}
+
+.mr_20 {
+  margin-right: 20px !important;
+}
+
+.nmt_20 {
+  margin-top: -20px !important;
+}
+
+.nmb_20 {
+  margin-bottom: -20px !important;
+}
+
+.nml_20 {
+  margin-left: -20px !important;
+}
+
+.nmr_20 {
+  margin-right: -20px !important;
+}
+
+.mt_25 {
+  margin-top: 25px !important;
+}
+
+.mb_25 {
+  margin-bottom: 25px !important;
+}
+
+.ml_25 {
+  margin-left: 25px !important;
+}
+
+.mr_25 {
+  margin-right: 25px !important;
+}
+
+.nmt_25 {
+  margin-top: -25px !important;
+}
+
+.nmb_25 {
+  margin-bottom: -25px !important;
+}
+
+.nml_25 {
+  margin-left: -25px !important;
+}
+
+.nmr_25 {
+  margin-right: -25px !important;
+}
+
+.mt_30 {
+  margin-top: 30px !important;
+}
+
+.mb_30 {
+  margin-bottom: 30px !important;
+}
+
+.ml_30 {
+  margin-left: 30px !important;
+}
+
+.mr_30 {
+  margin-right: 30px !important;
+}
+
+.nmt_30 {
+  margin-top: -30px !important;
+}
+
+.nmb_30 {
+  margin-bottom: -30px !important;
+}
+
+.nml_30 {
+  margin-left: -30px !important;
+}
+
+.nmr_30 {
+  margin-right: -30px !important;
+}
+
+.mt_35 {
+  margin-top: 35px !important;
+}
+
+.mb_35 {
+  margin-bottom: 35px !important;
+}
+
+.ml_35 {
+  margin-left: 35px !important;
+}
+
+.mr_35 {
+  margin-right: 35px !important;
+}
+
+.nmt_35 {
+  margin-top: -35px !important;
+}
+
+.nmb_35 {
+  margin-bottom: -35px !important;
+}
+
+.nml_35 {
+  margin-left: -35px !important;
+}
+
+.nmr_35 {
+  margin-right: -35px !important;
+}
+
+.mt_40 {
+  margin-top: 40px !important;
+}
+
+.mb_40 {
+  margin-bottom: 40px !important;
+}
+
+.ml_40 {
+  margin-left: 40px !important;
+}
+
+.mr_40 {
+  margin-right: 40px !important;
+}
+
+.nmt_40 {
+  margin-top: -40px !important;
+}
+
+.nmb_40 {
+  margin-bottom: -40px !important;
+}
+
+.nml_40 {
+  margin-left: -40px !important;
+}
+
+.nmr_40 {
+  margin-right: -40px !important;
+}
+
+.mt_45 {
+  margin-top: 45px !important;
+}
+
+.mb_45 {
+  margin-bottom: 45px !important;
+}
+
+.ml_45 {
+  margin-left: 45px !important;
+}
+
+.mr_45 {
+  margin-right: 45px !important;
+}
+
+.nmt_45 {
+  margin-top: -45px !important;
+}
+
+.nmb_45 {
+  margin-bottom: -45px !important;
+}
+
+.nml_45 {
+  margin-left: -45px !important;
+}
+
+.nmr_45 {
+  margin-right: -45px !important;
+}
+
+.mt_50 {
+  margin-top: 50px !important;
+}
+
+.mb_50 {
+  margin-bottom: 50px !important;
+}
+
+.ml_50 {
+  margin-left: 50px !important;
+}
+
+.mr_50 {
+  margin-right: 50px !important;
+}
+
+.nmt_50 {
+  margin-top: -50px !important;
+}
+
+.nmb_50 {
+  margin-bottom: -50px !important;
+}
+
+.nml_50 {
+  margin-left: -50px !important;
+}
+
+.nmr_50 {
+  margin-right: -50px !important;
+}
+
+.mt_55 {
+  margin-top: 55px !important;
+}
+
+.mb_55 {
+  margin-bottom: 55px !important;
+}
+
+.ml_55 {
+  margin-left: 55px !important;
+}
+
+.mr_55 {
+  margin-right: 55px !important;
+}
+
+.nmt_55 {
+  margin-top: -55px !important;
+}
+
+.nmb_55 {
+  margin-bottom: -55px !important;
+}
+
+.nml_55 {
+  margin-left: -55px !important;
+}
+
+.nmr_55 {
+  margin-right: -55px !important;
+}
+
+.mt_60 {
+  margin-top: 60px !important;
+}
+
+.mb_60 {
+  margin-bottom: 60px !important;
+}
+
+.ml_60 {
+  margin-left: 60px !important;
+}
+
+.mr_60 {
+  margin-right: 60px !important;
+}
+
+.nmt_60 {
+  margin-top: -60px !important;
+}
+
+.nmb_60 {
+  margin-bottom: -60px !important;
+}
+
+.nml_60 {
+  margin-left: -60px !important;
+}
+
+.nmr_60 {
+  margin-right: -60px !important;
+}
+
+.mt_65 {
+  margin-top: 65px !important;
+}
+
+.mb_65 {
+  margin-bottom: 65px !important;
+}
+
+.ml_65 {
+  margin-left: 65px !important;
+}
+
+.mr_65 {
+  margin-right: 65px !important;
+}
+
+.nmt_65 {
+  margin-top: -65px !important;
+}
+
+.nmb_65 {
+  margin-bottom: -65px !important;
+}
+
+.nml_65 {
+  margin-left: -65px !important;
+}
+
+.nmr_65 {
+  margin-right: -65px !important;
+}
+
+.mt_70 {
+  margin-top: 70px !important;
+}
+
+.mb_70 {
+  margin-bottom: 70px !important;
+}
+
+.ml_70 {
+  margin-left: 70px !important;
+}
+
+.mr_70 {
+  margin-right: 70px !important;
+}
+
+.nmt_70 {
+  margin-top: -70px !important;
+}
+
+.nmb_70 {
+  margin-bottom: -70px !important;
+}
+
+.nml_70 {
+  margin-left: -70px !important;
+}
+
+.nmr_70 {
+  margin-right: -70px !important;
+}
+
+.mt_75 {
+  margin-top: 75px !important;
+}
+
+.mb_75 {
+  margin-bottom: 75px !important;
+}
+
+.ml_75 {
+  margin-left: 75px !important;
+}
+
+.mr_75 {
+  margin-right: 75px !important;
+}
+
+.nmt_75 {
+  margin-top: -75px !important;
+}
+
+.nmb_75 {
+  margin-bottom: -75px !important;
+}
+
+.nml_75 {
+  margin-left: -75px !important;
+}
+
+.nmr_75 {
+  margin-right: -75px !important;
+}
+
+.mt_80 {
+  margin-top: 80px !important;
+}
+
+.mb_80 {
+  margin-bottom: 80px !important;
+}
+
+.ml_80 {
+  margin-left: 80px !important;
+}
+
+.mr_80 {
+  margin-right: 80px !important;
+}
+
+.nmt_80 {
+  margin-top: -80px !important;
+}
+
+.nmb_80 {
+  margin-bottom: -80px !important;
+}
+
+.nml_80 {
+  margin-left: -80px !important;
+}
+
+.nmr_80 {
+  margin-right: -80px !important;
+}
+
+.mt_85 {
+  margin-top: 85px !important;
+}
+
+.mb_85 {
+  margin-bottom: 85px !important;
+}
+
+.ml_85 {
+  margin-left: 85px !important;
+}
+
+.mr_85 {
+  margin-right: 85px !important;
+}
+
+.nmt_85 {
+  margin-top: -85px !important;
+}
+
+.nmb_85 {
+  margin-bottom: -85px !important;
+}
+
+.nml_85 {
+  margin-left: -85px !important;
+}
+
+.nmr_85 {
+  margin-right: -85px !important;
+}
+
+.mt_90 {
+  margin-top: 90px !important;
+}
+
+.mb_90 {
+  margin-bottom: 90px !important;
+}
+
+.ml_90 {
+  margin-left: 90px !important;
+}
+
+.mr_90 {
+  margin-right: 90px !important;
+}
+
+.nmt_90 {
+  margin-top: -90px !important;
+}
+
+.nmb_90 {
+  margin-bottom: -90px !important;
+}
+
+.nml_90 {
+  margin-left: -90px !important;
+}
+
+.nmr_90 {
+  margin-right: -90px !important;
+}
+
+.mt_95 {
+  margin-top: 95px !important;
+}
+
+.mb_95 {
+  margin-bottom: 95px !important;
+}
+
+.ml_95 {
+  margin-left: 95px !important;
+}
+
+.mr_95 {
+  margin-right: 95px !important;
+}
+
+.nmt_95 {
+  margin-top: -95px !important;
+}
+
+.nmb_95 {
+  margin-bottom: -95px !important;
+}
+
+.nml_95 {
+  margin-left: -95px !important;
+}
+
+.nmr_95 {
+  margin-right: -95px !important;
+}
+
+.mt_100 {
+  margin-top: 100px !important;
+}
+
+.mb_100 {
+  margin-bottom: 100px !important;
+}
+
+.ml_100 {
+  margin-left: 100px !important;
+}
+
+.mr_100 {
+  margin-right: 100px !important;
+}
+
+.nmt_100 {
+  margin-top: -100px !important;
+}
+
+.nmb_100 {
+  margin-bottom: -100px !important;
+}
+
+.nml_100 {
+  margin-left: -100px !important;
+}
+
+.nmr_100 {
+  margin-right: -100px !important;
+}
+
+.padding_0 {
+  padding: 0 !important;
+}
+
+.padding_01 {
+  padding: 1px !important;
+}
+
+.padding_02 {
+  padding: 2px !important;
+}
+
+.padding_03 {
+  padding: 3px !important;
+}
+
+.padding_04 {
+  padding: 4px !important;
+}
+
+.padding_05 {
+  padding: 5px !important;
+}
+
+.padding_06 {
+  padding: 6px !important;
+}
+
+.padding_07 {
+  padding: 7px !important;
+}
+
+.padding_08 {
+  padding: 8px !important;
+}
+
+.padding_09 {
+  padding: 9px !important;
+}
+
+.padding_5 {
+  padding: 5px !important;
+}
+
+.padding_10 {
+  padding: 10px !important;
+}
+
+.padding_15 {
+  padding: 15px !important;
+}
+
+.padding_20 {
+  padding: 20px !important;
+}
+
+.padding_25 {
+  padding: 25px !important;
+}
+
+.padding_30 {
+  padding: 30px !important;
+}
+
+.padding_35 {
+  padding: 35px !important;
+}
+
+.padding_40 {
+  padding: 40px !important;
+}
+
+.padding_45 {
+  padding: 45px !important;
+}
+
+.padding_50 {
+  padding: 50px !important;
+}
+
+.padding_55 {
+  padding: 55px !important;
+}
+
+.padding_60 {
+  padding: 60px !important;
+}
+
+.padding_65 {
+  padding: 65px !important;
+}
+
+.padding_70 {
+  padding: 70px !important;
+}
+
+.padding_75 {
+  padding: 75px !important;
+}
+
+.padding_80 {
+  padding: 80px !important;
+}
+
+.padding_85 {
+  padding: 85px !important;
+}
+
+.padding_90 {
+  padding: 90px !important;
+}
+
+.padding_95 {
+  padding: 95px !important;
+}
+
+.padding_100 {
+  padding: 100px !important;
+}
+
+.pr_60 {
+  padding-right: 65px !important;
+}
+
+.pl_60 {
+  padding-left: 60px !important;
+}
+
+/*----------------------------------------------------
+角丸具合
+----------------------------------------------------*/
+.radius_0 {
+  -moz-border-radius: 0;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+}
+
+.radius_01 {
+  -moz-border-radius: 1px;
+  -webkit-border-radius: 1px;
+  border-radius: 1px;
+}
+
+.radius_02 {
+  -moz-border-radius: 2px;
+  -webkit-border-radius: 2px;
+  border-radius: 2px;
+}
+
+.radius_03 {
+  -moz-border-radius: 3px;
+  -webkit-border-radius: 3px;
+  border-radius: 3px;
+}
+
+.radius_04 {
+  -moz-border-radius: 4px;
+  -webkit-border-radius: 4px;
+  border-radius: 4px;
+}
+
+.radius_05 {
+  -moz-border-radius: 5px;
+  -webkit-border-radius: 5px;
+  border-radius: 5px;
+}
+
+.radius_06 {
+  -moz-border-radius: 6px;
+  -webkit-border-radius: 6px;
+  border-radius: 6px;
+}
+
+.radius_07 {
+  -moz-border-radius: 7px;
+  -webkit-border-radius: 7px;
+  border-radius: 7px;
+}
+
+.radius_08 {
+  -moz-border-radius: 8px;
+  -webkit-border-radius: 8px;
+  border-radius: 8px;
+}
+
+.radius_09 {
+  -moz-border-radius: 9px;
+  -webkit-border-radius: 9px;
+  border-radius: 9px;
+}
+
+.radius_10 {
+  -moz-border-radius: 10px;
+  -webkit-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.radius_11 {
+  -moz-border-radius: 11px;
+  -webkit-border-radius: 11px;
+  border-radius: 11px;
+}
+
+.radius_12 {
+  -moz-border-radius: 12px;
+  -webkit-border-radius: 12px;
+  border-radius: 12px;
+}
+
+.radius_13 {
+  -moz-border-radius: 13px;
+  -webkit-border-radius: 13px;
+  border-radius: 13px;
+}
+
+.radius_14 {
+  -moz-border-radius: 14px;
+  -webkit-border-radius: 14px;
+  border-radius: 14px;
+}
+
+.radius_15 {
+  -moz-border-radius: 15px;
+  -webkit-border-radius: 15px;
+  border-radius: 15px;
+}
+
+.radius_16 {
+  -moz-border-radius: 16px;
+  -webkit-border-radius: 16px;
+  border-radius: 16px;
+}
+
+.radius_17 {
+  -moz-border-radius: 17px;
+  -webkit-border-radius: 17px;
+  border-radius: 17px;
+}
+
+.radius_18 {
+  -moz-border-radius: 18px;
+  -webkit-border-radius: 18px;
+  border-radius: 18px;
+}
+
+.radius_19 {
+  -moz-border-radius: 19px;
+  -webkit-border-radius: 19px;
+  border-radius: 19px;
+}
+
+.radius_20 {
+  -moz-border-radius: 20px;
+  -webkit-border-radius: 20px;
+  border-radius: 20px;
+}
+
+.round50 {
+  -moz-border-radius: 50%;
+  -webkit-border-radius: 50%;
+  border-radius: 50%;
+}
+
+/*----------------------------------------------------
+フォント
+----------------------------------------------------*/
+.font10 {
+  font-size: 10px !important;
+}
+
+.font11 {
+  font-size: 11px !important;
+}
+
+.font12 {
+  font-size: 12px !important;
+}
+
+.font13 {
+  font-size: 13px !important;
+}
+
+.font14 {
+  font-size: 14px !important;
+}
+
+.font15 {
+  font-size: 15px !important;
+}
+
+.font16 {
+  font-size: 16px !important;
+}
+
+.font17 {
+  font-size: 17px !important;
+}
+
+.font18 {
+  font-size: 18px !important;
+}
+
+.font19 {
+  font-size: 19px !important;
+}
+
+.font20 {
+  font-size: 20px !important;
+}
+
+.font21 {
+  font-size: 21px !important;
+}
+
+.font22 {
+  font-size: 22px !important;
+}
+
+.font23 {
+  font-size: 23px !important;
+}
+
+.font24 {
+  font-size: 24px !important;
+}
+
+.font25 {
+  font-size: 25px !important;
+}
+
+.font26 {
+  font-size: 26px !important;
+}
+
+.font27 {
+  font-size: 27px !important;
+}
+
+.font28 {
+  font-size: 28px !important;
+}
+
+.font29 {
+  font-size: 29px !important;
+}
+
+.font30 {
+  font-size: 30px !important;
+}
+
+.font31 {
+  font-size: 31px !important;
+}
+
+.font32 {
+  font-size: 32px !important;
+}
+
+.font33 {
+  font-size: 33px !important;
+}
+
+.font34 {
+  font-size: 34px !important;
+}
+
+.font35 {
+  font-size: 35px !important;
+}
+
+.font36 {
+  font-size: 36px !important;
+}
+
+.font37 {
+  font-size: 37px !important;
+}
+
+.font38 {
+  font-size: 38px !important;
+}
+
+.font39 {
+  font-size: 39px !important;
+}
+
+.font40 {
+  font-size: 40px !important;
+}
+
+.font41 {
+  font-size: 41px !important;
+}
+
+.font42 {
+  font-size: 42px !important;
+}
+
+.font43 {
+  font-size: 43px !important;
+}
+
+.font44 {
+  font-size: 44px !important;
+}
+
+.font45 {
+  font-size: 45px !important;
+}
+
+.font46 {
+  font-size: 46px !important;
+}
+
+.font47 {
+  font-size: 47px !important;
+}
+
+.font48 {
+  font-size: 48px !important;
+}
+
+.font49 {
+  font-size: 49px !important;
+}
+
+.font50 {
+  font-size: 50px !important;
+}
+
+.bold {
+  font-weight: bold !important;
+}
+
+.text-left {
+  text-align: left !important;
+}
+
+.text-center {
+  text-align: center !important;
+}
+
+.text-right {
+  text-align: right !important;
+}
+
+.lh100 {
+  line-height: 1 !important;
+}
+
+.lh120 {
+  line-height: 1.2 !important;
+}
+
+.lh150 {
+  line-height: 1.5 !important;
+}
+
+.lh175 {
+  line-height: 1.75 !important;
+}
+
+.lh200 {
+  line-height: 2 !important;
+}
+
+.lh300 {
+  line-height: 3 !important;
+}
+
+/*----------------------------------------------------
+valign
+----------------------------------------------------*/
+.valign-top {
+  vertical-align: top !important;
+}
+
+.valign-middle {
+  vertical-align: middle !important;
+}
+
+.valign-bottom {
+  vertical-align: bottom !important;
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!
+
   def index
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,4 @@
+class UsersController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,34 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_user, only: [:edit, :update]
 
   def index
+  end
+
+  def edit
+  end
+
+  def update
+    if @user.update!(update_params)
+      redirect_to edit_user_path, notice: "保存しました"
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def update_params
+    params.require(:user).permit(
+      :email,
+      :name,
+      :birthday,
+      :gender,
+      :school
+    )
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,6 @@
+class User < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :trackable, :validatable
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  enum gender: { man: 0, woman: 1 }
 end

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @email %>!</p>
+
+<% if @resource.try(:unconfirmed_email?) %>
+  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+<% else %>
+  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+<% end %>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,0 +1,3 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>We're contacting you to notify you that your password has been changed.</p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,0 +1,25 @@
+<h2>Change your password</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= devise_error_messages! %>
+  <%= f.hidden_field :reset_password_token %>
+
+  <div class="field">
+    <%= f.label :password, "New password" %><br />
+    <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+    <% end %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation, "Confirm new password" %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Change my password" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Forgot your password?</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Send me reset password instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,0 +1,43 @@
+<h2>Edit <%= resource_name.to_s.humanize %></h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.password_field :password, autocomplete: "off" %>
+    <% if @minimum_password_length %>
+      <br />
+      <em><%= @minimum_password_length %> characters minimum</em>
+    <% end %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.password_field :current_password, autocomplete: "off" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Update" %>
+  </div>
+<% end %>
+
+<h3>Cancel my account</h3>
+
+<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+
+<%= link_to "Back", :back %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,29 @@
+<h2>Sign up</h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %>
+    <% if @minimum_password_length %>
+    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <% end %><br />
+    <%= f.password_field :password, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Sign up" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,28 +1,38 @@
-<h2>Sign up</h2>
-
+<h2>ユーザー登録</h2>
+<% flash.each do |message_type, message| %>
+  <div>
+    <% if (message_type=="alert") %>
+      <%= content_tag(:div, message, class: "alert alert-danger") %>
+    <% elsif (message_type=="notice") %>
+      <%= content_tag(:div, message, class: "alert alert-success") %>
+    <% else %>
+      <%= content_tag(:div, message, class: "alert alert-#{message_type}") %>
+    <% end %>
+  </div>
+<% end %>
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= devise_error_messages! %>
 
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :email, "Eメール" %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
-
+  <br>
   <div class="field">
-    <%= f.label :password %>
+    <%= f.label :password, "パスワード" %>
     <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <em>（<%= @minimum_password_length %> 文字以上で入力してください）</em>
     <% end %><br />
     <%= f.password_field :password, autocomplete: "off" %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
+  <br>
+  <div class="field mb_20">
+    <%= f.label :password_confirmation, "パスワード（確認用）" %><br />
     <%= f.password_field :password_confirmation, autocomplete: "off" %>
   </div>
 
-  <div class="actions">
-    <%= f.submit "Sign up" %>
+  <div class="actions mb_15">
+    <%= f.submit "登録", class: "btn btn-primary" %>
   </div>
 <% end %>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -15,7 +15,7 @@
 
   <div class="field">
     <%= f.label :email, "Eメール" %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
   </div>
   <br>
   <div class="field">
@@ -23,12 +23,12 @@
     <% if @minimum_password_length %>
     <em>（<%= @minimum_password_length %> 文字以上で入力してください）</em>
     <% end %><br />
-    <%= f.password_field :password, autocomplete: "off" %>
+    <%= f.password_field :password, autocomplete: "off", class: "form-control" %>
   </div>
   <br>
   <div class="field mb_20">
     <%= f.label :password_confirmation, "パスワード（確認用）" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+    <%= f.password_field :password_confirmation, autocomplete: "off", class: "form-control" %>
   </div>
 
   <div class="actions mb_15">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,26 @@
+<h2>Log in</h2>
+
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %><br />
+    <%= f.password_field :password, autocomplete: "off" %>
+  </div>
+
+  <% if devise_mapping.rememberable? -%>
+    <div class="field">
+      <%= f.check_box :remember_me %>
+      <%= f.label :remember_me %>
+    </div>
+  <% end -%>
+
+  <div class="actions">
+    <%= f.submit "Log in" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,25 +1,35 @@
-<h2>Log in</h2>
-
+<h2>ログイン</h2>
+<% flash.each do |message_type, message| %>
+  <div>
+    <% if (message_type=="alert") %>
+      <%= content_tag(:div, message, class: "alert alert-danger") %>
+    <% elsif (message_type=="notice") %>
+      <%= content_tag(:div, message, class: "alert alert-success") %>
+    <% else %>
+      <%= content_tag(:div, message, class: "alert alert-#{message_type}") %>
+    <% end %>
+  </div>
+<% end %>
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.label :email, "Eメール" %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
   </div>
-
+  <br>
   <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "off" %>
+    <%= f.label :password, "パスワード" %><br />
+    <%= f.password_field :password, autocomplete: "off", class: "form-control" %>
   </div>
-
+  <br>
   <% if devise_mapping.rememberable? -%>
-    <div class="field">
+    <div class="field mb_20">
       <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+      <%= f.label :remember_me, "ログインを記憶する" %>
     </div>
   <% end -%>
 
-  <div class="actions">
-    <%= f.submit "Log in" %>
+  <div class="actions mb_15">
+    <%= f.submit "ログイン", class: "btn btn-success" %>
   </div>
 <% end %>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
+  <% end -%>
+<% end -%>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,14 +1,14 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "ログイン画面へ", new_session_path(resource_name), class: "btn btn-default" %><br />
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "ユーザー登録", new_registration_path(resource_name), class: "btn btn-default" %><br />
 <% end -%>
-
+<!--
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
   <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
-<% end -%>
+<% end -%> -->
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
   <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend unlock instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend unlock instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,8 @@
   </head>
 
   <body>
+    <p class="notice"><%= notice %></p>
+    <p class="alert"><%= alert %></p>
     <%= yield %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,10 @@
     <div class="container">
       <nav class="navbar navbar-expand-lg navbar-light bg-faded">
         <%= link_to 'e-Navigator', root_path, class: "site-title" %>
+        <% if user_signed_in? %>
+          <%= link_to 'プロフィール', edit_user_registration_path(current_user), class: "nav-title" %>
+          <%= link_to 'ログアウト', destroy_user_session_path, method: "delete", class: "nav-title" %>
+        <% end %>
       </nav>
       <%= yield %>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,18 +6,13 @@
 
     <%= stylesheet_link_tag    'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
-
-    <!-- Compiled and minified CSS -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/css/materialize.min.css">
-
-    <!-- Compiled and minified JavaScript -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/js/materialize.min.js"></script>
   </head>
 
   <body>
-    <p class="notice"><%= notice %></p>
-    <p class="alert"><%= alert %></p>
-    <div id="wrap">
+    <div class="container">
+      <nav class="navbar navbar-expand-lg navbar-light bg-faded">
+        <%= link_to 'e-Navigator', root_path, class: "site-title" %>
+      </nav>
       <%= yield %>
     </div>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,11 +6,19 @@
 
     <%= stylesheet_link_tag    'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
+
+    <!-- Compiled and minified CSS -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/css/materialize.min.css">
+
+    <!-- Compiled and minified JavaScript -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/js/materialize.min.js"></script>
   </head>
 
   <body>
     <p class="notice"><%= notice %></p>
     <p class="alert"><%= alert %></p>
-    <%= yield %>
+    <div id="wrap">
+      <%= yield %>
+    </div>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
       <nav class="navbar navbar-expand-lg navbar-light bg-faded">
         <%= link_to 'e-Navigator', root_path, class: "site-title" %>
         <% if user_signed_in? %>
-          <%= link_to 'プロフィール', edit_user_registration_path(current_user), class: "nav-title" %>
+          <%= link_to 'プロフィール', edit_user_path(current_user), class: "nav-title" %>
           <%= link_to 'ログアウト', destroy_user_session_path, method: "delete", class: "nav-title" %>
         <% end %>
       </nav>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,44 @@
+<h2>プロフィール</h2>
+<% flash.each do |message_type, message| %>
+  <div>
+    <% if (message_type=="alert") %>
+      <%= content_tag(:div, message, class: "alert alert-danger") %>
+    <% elsif (message_type=="notice") %>
+      <%= content_tag(:div, message, class: "alert alert-success") %>
+    <% else %>
+      <%= content_tag(:div, message, class: "alert alert-#{message_type}") %>
+    <% end %>
+  </div>
+<% end %>
+<%= form_for(@user) do |f| %>
+
+  <div class="field">
+    <%= f.label :email, "Eメール" %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+  </div>
+  <br>
+  <div class="field">
+    <%= f.label :name, "名前" %><br />
+    <%= f.text_field :name, class: "form-control" %>
+  </div>
+  <br>
+  <div class="field">
+    <%= f.label :birthday, "生年月日" %><br />
+    <%= f.date_select :birthday, { start_year: 1950, end_year: Time.now.year }, { class: "form-control", style: "display: inline-block; width: auto;" } %>
+  </div>
+  <br>
+  <div class="field">
+    <%= f.label :gender, "性別" %><br />
+    <%= f.select :gender, [['男性', 'man'], ['女性', 'woman']], {}, class: "form-control", style: "width: auto;" %>
+  </div>
+  <br>
+  <div class="field">
+    <%= f.label :school, "学校名" %><br />
+    <%= f.text_field :school, class: "form-control" %>
+  </div>
+  <br>
+
+  <div class="actions mb_15">
+    <%= f.submit "登録する", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Users#index</h1>
+<p>Find me in app/views/users/index.html.erb</p>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,2 +1,0 @@
-<h1>Users#index</h1>
-<p>Find me in app/views/users/index.html.erb</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,10 @@ module ENavigator
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+    config.generators do |g|
+      g.helper false
+      g.assets false
+      g.test_framework false
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,7 @@ module ENavigator
       g.assets false
       g.test_framework false
     end
+
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,6 +31,9 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # mailer setting
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local       = true
   config.action_controller.perform_caching = true
 
   # Attempt to read encrypted secrets from `config/secrets.yml.enc`.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,279 @@
+# frozen_string_literal: true
+
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = '4911c8b86df96df4d4feb83f39953af4945f3c2fa838b928089771fd43ce4911b0bc0d8dded7db7dac012091d8bda8a95d45ddbfe981195b21942b780a86f999'
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # Configure the parent class responsible to send e-mails.
+  # config.parent_mailer = 'ActionMailer::Base'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [:email]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [:email]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [:email]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication. The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # When false, Devise will not attempt to reload routes on eager load.
+  # This can reduce the time taken to boot the app but if your application
+  # requires the Devise mappings to be loaded during boot time the application
+  # won't boot properly.
+  # config.reload_routes = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 11. If
+  # using other algorithms, it sets how many times you want the password to be hashed.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # algorithm), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 11
+
+  # Set up a pepper to generate the hashed password.
+  # config.pepper = '56b86c5cf9e0cc3280f82d339b863fbbe90b13a773d8807fa413adc5bb434175058b4d56b73bfa75e11c9c704332bf9711d2493c629aa40c7efa11c6813e40b5'
+
+  # Send a notification to the original email when the user's email is changed.
+  # config.send_email_changed_notification = false
+
+  # Send a notification email when the user's password is changed.
+  # config.send_password_change_notification = false
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day. Default is 0.days, meaning
+  # the user cannot access the website without confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [:email]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 6..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [:email]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [:email]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  # config.sign_in_after_reset_password = true
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
+  # You can use :sha1, :sha512 or algorithms from others authentication tools as
+  # :clearance_sha1, :authlogic_sha512 (then you should set stretches above to 20
+  # for default behavior) and :restful_authentication_sha1 (then you should set
+  # stretches to 10, and copy REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html, should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,0 +1,64 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,68 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+ja:
+  devise:
+    confirmations:
+      confirmed: 'アカウントを登録しました。'
+      send_instructions: 'アカウントの有効化について数分以内にメールでご連絡します。'
+      send_paranoid_instructions: "あなたのメールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。"
+    failure:
+      already_authenticated: 'すでにログインしています。'
+      inactive: 'アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。'
+      invalid: "%{authentication_keys} もしくはパスワードが間違っています。"
+      locked: 'あなたのアカウントは凍結されています。'
+      last_attempt: 'あなたのアカウントが凍結される前に、複数回の操作がおこなわれています。'
+      not_found_in_database: "%{authentication_keys} もしくはパスワードが間違っています。"
+      timeout: 'セッションがタイムアウトしました。もう一度ログインしてください。'
+      unauthenticated: 'アカウント登録もしくはログインしてください。'
+      unconfirmed: 'メールアドレスの本人確認が必要です。'
+    mailer:
+      confirmation_instructions:
+        subject: '[リクシェア for kintone] 新規会員登録を受け付けました'
+      reset_password_instructions:
+        subject: '[リクシェア for kintone] パスワード再設定URLをお送りします'
+      unlock_instructions:
+        subject: 'アカウントの凍結解除について'
+      password_change:
+        subject: 'パスワードの変更について'
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      no_token: "このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。"
+      send_instructions: 'パスワードの再設定について数分以内にメールでご連絡いたします。'
+      send_paranoid_instructions: "あなたのメールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。"
+      updated: 'パスワードが正しく変更されました。'
+      updated_not_active: 'パスワードが正しく変更されました。'
+    registrations:
+      destroyed: 'アカウントを削除しました。またのご利用をお待ちしております。'
+      signed_up: 'アカウント登録が完了しました。'
+      signed_up_but_inactive: 'ログインするためには、アカウントを有効化してください。'
+      signed_up_but_locked: 'アカウントが凍結されているためログインできません。'
+      signed_up_but_unconfirmed: '本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。'
+      update_needs_confirmation: 'アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。'
+      updated: 'アカウント情報を変更しました。'
+    sessions:
+      signed_in: 'ログインしました。'
+      signed_out: 'ログアウトしました。'
+      already_signed_out: '既にログアウト済みです。'
+    unlocks:
+      send_instructions: 'アカウントの凍結解除方法を数分以内にメールでご連絡します。'
+      send_paranoid_instructions: 'アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。'
+      unlocked: 'アカウントを凍結解除しました。'
+  errors:
+    messages:
+      already_confirmed: 'は既に認証確認済みです。ログインしてください。'
+      confirmation_period_expired: "の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。"
+      expired: 'の有効期限が切れました。新しくリクエストしてください。'
+      not_found: 'は存在しませんでした。入力いただいた内容に間違いがあるか、ご登録されていない可能性があります。'
+      not_locked: 'は凍結されていません。'
+      not_saved:
+        one: "エラーが発生したため %{resource} は保存されませんでした:"
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした:"
+        taken: "は既に使用されています。"
+        blank: "が入力されていません。"
+        too_short: "は%{count}文字以上に設定して下さい。"
+        too_long: "は%{count}文字以下に設定して下さい。"
+        invalid: "は有効でありません。"
+        confirmation: "が内容とあっていません。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,69 @@
+ja:
+  datetime:
+    distance_in_words:
+      half_a_minute: "30秒前後"
+      less_than_x_seconds:
+        one:   "1秒"
+        other: "%{count}秒"
+      x_seconds:
+        one:   "1秒"
+        other: "%{count}秒"
+      less_than_x_minutes:
+        one:   "1分"
+        other: "%{count}分"
+      x_minutes:
+        one:   "約1分"
+        other: "%{count}分"
+      about_x_hours:
+        one:   "約1時間"
+        other: "約%{count}時間"
+      x_days:
+        one:   "1日"
+        other: "%{count}日"
+      about_x_months:
+        one:   "約1ヶ月"
+        other: "約%{count}ヶ月"
+      x_months:
+        one:   "1ヶ月"
+        other: "%{count}ヶ月"
+      almost_x_years:
+        one:   "１年弱"
+        other: "%{count}年弱"
+      about_x_years:
+        one:   "約1年"
+        other: "約%{count}年"
+      over_x_years:
+        one:   "1年以上"
+        other: "%{count}年以上"
+  date:
+    formats:
+      default: "%Y/%m/%d"
+      short: "%m/%d"
+      long: "%Y年%m月%d日(%a)"
+
+    day_names: [日曜日, 月曜日, 火曜日, 水曜日, 木曜日, 金曜日, 土曜日]
+    abbr_day_names: [日, 月, 火, 水, 木, 金, 土]
+
+    month_names: [~, 1月, 2月, 3月, 4月, 5月, 6月, 7月, 8月, 9月, 10月, 11月, 12月]
+    abbr_month_names: [~, 1月, 2月, 3月, 4月, 5月, 6月, 7月, 8月, 9月, 10月, 11月, 12月]
+
+    order:
+      - :year
+      - :month
+      - :day
+
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"
+      short: "%y/%m/%d %H:%M"
+      long: "%Y年%m月%d日(%a) %H時%M分%S秒 %Z"
+    am: "午前"
+    pm: "午後"
+
+  views:
+    pagination:
+      first: <p class="page"><i class="glyphicon glyphicon-chevron-left" aria-hidden="true"></i></p>
+      last: <p class="page"><i class="glyphicon glyphicon-chevron-right" aria-hidden="true"></i></p>
+      previous: "&lsaquo; 前"
+      next:
+      truncate: "&hellip;"

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -1,0 +1,16 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+    attributes:
+      user:
+        email: メールアドレス
+        password: パスワード
+        name: 名前
+        birthday: 生年月日
+        gender: 性別
+        school: 学校名
+        created_at: 登録日時
+        updated_at: 更新日時
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  root 'users#index'
+
+  get 'users/index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  devise_for :users
   root 'users#index'
 
   get 'users/index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root 'users#index'
 
-  get 'users/index'
+  resources :users, only: [:index, :edit, :update]
 end

--- a/db/migrate/20180212160843_devise_create_users.rb
+++ b/db/migrate/20180212160843_devise_create_users.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class DeviseCreateUsers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :users do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.inet     :current_sign_in_ip
+      t.inet     :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+
+      t.timestamps null: false
+    end
+
+    add_index :users, :email,                unique: true
+    add_index :users, :reset_password_token, unique: true
+    # add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,         unique: true
+  end
+end

--- a/db/migrate/20180212160843_devise_create_users.rb
+++ b/db/migrate/20180212160843_devise_create_users.rb
@@ -32,7 +32,11 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.1]
       # t.string   :unlock_token # Only if unlock strategy is :email or :both
       # t.datetime :locked_at
 
-
+      ## Profile
+      t.string  :name
+      t.date    :birthday
+      t.string  :gender
+      t.string  :school
       t.timestamps null: false
     end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,6 +26,10 @@ ActiveRecord::Schema.define(version: 20180212160843) do
     t.datetime "last_sign_in_at"
     t.inet "current_sign_in_ip"
     t.inet "last_sign_in_ip"
+    t.string "name"
+    t.date "birthday"
+    t.string "gender"
+    t.string "school"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 20180212160843) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
 
 end


### PR DESCRIPTION
やりたかったこと
---
- ユーザー登録、ログイン機能の追加
- 登録したユーザーのプロフィール編集機能の追加

やったこと
----
- Devise gem の導入
- ユーザー登録、ログイン機能、プロフィール編集機能、トップページの追加
- Bootstrapの追加

動作確認方法
---
https://e-navigator-tanakamana.herokuapp.com/users/sign_in

- [ ] 「ユーザー登録」ボタンからをユーザーを新規で作成する
- [ ] ヘッダーのプロフィールボタンからプロフィールの確認・編集画面にいく
- [ ] 入力されていないプロフィールを入力して、「登録する」ボタンを押す

その他
---
- Bootstrapの適用方法について
サンプルアプリでBootstrapが使われているようだったので、Bootstrapを適用させました。
gemのgem 'bootstrap-sass', '3.3.6'を追加し、appliation.css.scssに`@import "bootstrap-sprockets";
@import "bootstrap"`;を追記することで適用させたのですが、Bootstrapのサイトから直接ソースをダウンロードして使うこともできると思います。
Bootstrapのソースは直接いじらず上書きして変更していくこと、直接ダウンロードして入れるとパフォーマンスが悪くなりそうという点で今回のやり方でやったのですが、ベストなやり方があるのでしょうか？

- プロフィールの入力文字制限について
例えば名前のnameカラムをstring型で作っているので、1000文字以上入れると保存できないのですが、こういったケースなどあらゆる観点でバリデーションをかけておいた方がよいでしょうか？